### PR TITLE
New option for reading out the setting of the bias-tee added.

### DIFF
--- a/Note
+++ b/Note
@@ -25,6 +25,7 @@ BUILD AND INSTALL
     cmake ..
     make
     sudo make install
+    sudo ldconfig /usr/local/lib
 
 
 REFERENCES

--- a/Note
+++ b/Note
@@ -1,0 +1,39 @@
+NEW OPTION
+==========
+
+This branch implements an option for reading out the setting of the bias-tee.
+
+With option '-g' the setting is displayed:
+
+    rtl_biast -g
+
+
+Together with the '-b' option one can verify the setting immediately:
+
+    rtl_biast -b1 -g
+
+Or in short:
+
+    rtl_biast -gb1
+
+
+BUILD AND INSTALL
+=================
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+    sudo make install
+
+
+REFERENCES
+==========
+
+RTL-SDR Blog V.3. Dongles User Guide:
+
+    https://www.rtl-sdr.com/rtl-sdr-blog-v-3-dongles-user-guide/
+
+Using the RTL2832 GPIO port:
+
+    http://lea.hamradio.si/~s57uuu/mischam/rtlsdr/ports.html

--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -307,6 +307,18 @@ RTLSDR_API int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on);
 RTLSDR_API int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on);
 
 /*!
+ * Get bias tee setting on device dev.
+ */
+RTLSDR_API int rtlsdr_get_bias_tee(rtlsdr_dev_t *dev);
+
+/*!
+ * GPIO read functions.
+ */
+RTLSDR_API int rtlsdr_read_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio);
+RTLSDR_API void rtlsdr_get_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int *val);
+RTLSDR_API void rtlsdr_set_gpio_input(rtlsdr_dev_t *dev, uint8_t gpio);
+
+/*!
  * Get state of the direct sampling mode
  *
  * \param dev the device handle given by rtlsdr_open()

--- a/librtlsdr.c
+++ b/librtlsdr.c
@@ -554,6 +554,15 @@ int rtlsdr_demod_write_reg(rtlsdr_dev_t *dev, uint8_t page, uint16_t addr, uint1
 	return (r == len) ? 0 : -1;
 }
 
+void rtlsdr_get_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int *val)
+{
+	uint16_t r;
+
+	gpio = 1 << gpio;
+	r = rtlsdr_read_reg(dev, SYSB, GPI, 1);
+	*val = (r & gpio) ? 1 : 0;
+}
+
 void rtlsdr_set_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int val)
 {
 	uint16_t r;
@@ -562,6 +571,15 @@ void rtlsdr_set_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int val)
 	r = rtlsdr_read_reg(dev, SYSB, GPO, 1);
 	r = val ? (r | gpio) : (r & ~gpio);
 	rtlsdr_write_reg(dev, SYSB, GPO, r, 1);
+}
+
+int rtlsdr_read_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio)
+{
+	uint16_t r;
+
+	gpio = 1 << gpio;
+	r = rtlsdr_read_reg(dev, SYSB, GPO, 1);
+	return (r & gpio) ? 1 : 0;
 }
 
 void rtlsdr_set_gpio_output(rtlsdr_dev_t *dev, uint8_t gpio)
@@ -573,6 +591,17 @@ void rtlsdr_set_gpio_output(rtlsdr_dev_t *dev, uint8_t gpio)
 	rtlsdr_write_reg(dev, SYSB, GPD, r & ~gpio, 1); // CARL: Changed from rtlsdr_write_reg(dev, SYSB, GPO, r & ~gpio, 1); must be a bug in the old code
 	r = rtlsdr_read_reg(dev, SYSB, GPOE, 1);
 	rtlsdr_write_reg(dev, SYSB, GPOE, r | gpio, 1);
+}
+
+void rtlsdr_set_gpio_input(rtlsdr_dev_t *dev, uint8_t gpio)
+{
+	int r;
+	gpio = 1 << gpio;
+
+	r = rtlsdr_read_reg(dev, SYSB, GPD, 1);
+	rtlsdr_write_reg(dev, SYSB, GPD, r | gpio, 1);
+	r = rtlsdr_read_reg(dev, SYSB, GPOE, 1);
+	rtlsdr_write_reg(dev, SYSB, GPOE, r & ~gpio, 1);
 }
 
 void rtlsdr_set_i2c_repeater(rtlsdr_dev_t *dev, int on)
@@ -1176,6 +1205,14 @@ int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on)
 	rtlsdr_set_gpio_bit(dev, 0, on);
 
 	return 1;
+}
+
+int rtlsdr_get_bias_tee(rtlsdr_dev_t *dev)
+{
+	if (!dev)
+		return -1;
+
+	return rtlsdr_read_gpio_bit(dev, 0);
 }
 
 int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on)

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -554,6 +554,15 @@ int rtlsdr_demod_write_reg(rtlsdr_dev_t *dev, uint8_t page, uint16_t addr, uint1
 	return (r == len) ? 0 : -1;
 }
 
+void rtlsdr_get_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int *val)
+{
+	uint16_t r;
+
+	gpio = 1 << gpio;
+	r = rtlsdr_read_reg(dev, SYSB, GPI, 1);
+	*val = (r & gpio) ? 1 : 0;
+}
+
 void rtlsdr_set_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int val)
 {
 	uint16_t r;
@@ -562,6 +571,15 @@ void rtlsdr_set_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio, int val)
 	r = rtlsdr_read_reg(dev, SYSB, GPO, 1);
 	r = val ? (r | gpio) : (r & ~gpio);
 	rtlsdr_write_reg(dev, SYSB, GPO, r, 1);
+}
+
+int rtlsdr_read_gpio_bit(rtlsdr_dev_t *dev, uint8_t gpio)
+{
+	uint16_t r;
+
+	gpio = 1 << gpio;
+	r = rtlsdr_read_reg(dev, SYSB, GPO, 1);
+	return (r & gpio) ? 1 : 0;
 }
 
 void rtlsdr_set_gpio_output(rtlsdr_dev_t *dev, uint8_t gpio)
@@ -573,6 +591,17 @@ void rtlsdr_set_gpio_output(rtlsdr_dev_t *dev, uint8_t gpio)
 	rtlsdr_write_reg(dev, SYSB, GPD, r & ~gpio, 1); // CARL: Changed from rtlsdr_write_reg(dev, SYSB, GPO, r & ~gpio, 1); must be a bug in the old code
 	r = rtlsdr_read_reg(dev, SYSB, GPOE, 1);
 	rtlsdr_write_reg(dev, SYSB, GPOE, r | gpio, 1);
+}
+
+void rtlsdr_set_gpio_input(rtlsdr_dev_t *dev, uint8_t gpio)
+{
+	int r;
+	gpio = 1 << gpio;
+
+	r = rtlsdr_read_reg(dev, SYSB, GPD, 1);
+	rtlsdr_write_reg(dev, SYSB, GPD, r | gpio, 1);
+	r = rtlsdr_read_reg(dev, SYSB, GPOE, 1);
+	rtlsdr_write_reg(dev, SYSB, GPOE, r & ~gpio, 1);
 }
 
 void rtlsdr_set_i2c_repeater(rtlsdr_dev_t *dev, int on)
@@ -1176,6 +1205,14 @@ int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on)
 	rtlsdr_set_gpio_bit(dev, 0, on);
 
 	return 1;
+}
+
+int rtlsdr_get_bias_tee(rtlsdr_dev_t *dev)
+{
+	if (!dev)
+		return -1;
+
+	return rtlsdr_read_gpio_bit(dev, 0);
 }
 
 int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on)

--- a/src/rtl_biast.c
+++ b/src/rtl_biast.c
@@ -56,7 +56,8 @@ void usage(void)
 		"bias tee: rtl_biast -d 0 -b 1\n\n"
 		"Usage:\n"
 		"\t[-d device_index (default: 0)]\n"
-		"\t[-b bias_on (default: 0)]\n");
+		"\t[-b bias_on (default: 0)]\n"
+		"\t[-g (get bias setting)]\n");
 	exit(1);
 }
 
@@ -66,6 +67,8 @@ int main(int argc, char **argv)
 	uint32_t dev_index = 0;
 	uint32_t bias_on = 0;
 	int device_count;
+	int get_bias = 0;
+	int set_bias = 0;
 	char *filename = NULL;
 	FILE *file = NULL;
 	char *manuf_str = NULL;
@@ -79,13 +82,17 @@ int main(int argc, char **argv)
 	int ir_endpoint = 0;
 	char ch;
 
-	while ((opt = getopt(argc, argv, "d:b:h?")) != -1) {
+	while ((opt = getopt(argc, argv, "d:b:gh?")) != -1) {
 		switch (opt) {
 		case 'd':
 			dev_index = atoi(optarg);
 			break;
 		case 'b':
+			set_bias++;
 			bias_on = atoi(optarg);
+			break;
+		case 'g':
+			get_bias++;
 			break;
 		default:
 			usage();
@@ -95,7 +102,11 @@ int main(int argc, char **argv)
 
 	r = rtlsdr_open(&dev, dev_index);
 
-	rtlsdr_set_bias_tee(dev, bias_on);
+	if (set_bias || !get_bias)
+		rtlsdr_set_bias_tee(dev, bias_on);
+
+	if (get_bias)
+		printf("Bias-T = %d\n", rtlsdr_get_bias_tee(dev));
 
 	//rtlsdr_set_direct_sampling(dev, 1);
 


### PR DESCRIPTION
**NEW OPTION**

This branch implements an option for reading out the setting of the bias-tee.

With option '-g' the setting is displayed:

    rtl_biast -g


Together with the '-b' option one can verify the setting immediately:

    rtl_biast -b1 -g

Or in short:

    rtl_biast -gb1


**BUILD AND INSTALL**

    mkdir build
    cd build
    cmake ..
    make
    sudo make install
    sudo ldconfig /usr/local/lib