### PR TITLE
Added the ability to use the serial number when using -d.

### DIFF
--- a/src/rtl_biast.c
+++ b/src/rtl_biast.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "rtl-sdr.h"
+#include "convenience/convenience.h"
 
 #define EEPROM_SIZE	256
 #define MAX_STR_SIZE	256
@@ -65,7 +66,8 @@ void usage(void)
 int main(int argc, char **argv)
 {
 	int i, r, opt;
-	uint32_t dev_index = 0;
+	int dev_index = 0;
+	int dev_given = 0;
 	uint32_t bias_on = 0;
         uint32_t gpio_pin = 0;
 	int device_count;
@@ -85,7 +87,8 @@ int main(int argc, char **argv)
 	while ((opt = getopt(argc, argv, "d:b:g:h?")) != -1) {
 		switch (opt) {
 		case 'd':
-			dev_index = atoi(optarg);
+			dev_index = verbose_device_search(optarg);
+			dev_given = 1;
 			break;
 		case 'b':
 			bias_on = atoi(optarg);
@@ -97,6 +100,14 @@ int main(int argc, char **argv)
 			usage();
 			break;
 		}
+	}
+
+	if (!dev_given) {
+		dev_index = verbose_device_search("0");
+	}
+
+	if (dev_index < 0) {
+		exit(1);
 	}
 
 	r = rtlsdr_open(&dev, dev_index);


### PR DESCRIPTION
The one thing I found I wanted was the ability to specify which device I was trying to use by serial number instead of device index.  Specifically for my ADSB receiver that has two rtl devices attached (1 for 1090 and 1 for 978) but I only needed to enable the bias-t for one of them.

This is a small change to allow that based on other rtl command line tools.  See https://github.com/osmocom/rtl-sdr/blob/master/src/rtl_adsb.c