### PR TITLE
Fixes #8: Add rtl_biast message to beginning of output

### DIFF
--- a/src/rtl_biast.c
+++ b/src/rtl_biast.c
@@ -102,6 +102,8 @@ int main(int argc, char **argv)
 		}
 	}
 
+	printf("rtl_biast\n");
+
 	if (!dev_given) {
 		dev_index = verbose_device_search("0");
 	}


### PR DESCRIPTION
Fixes #8: Add rtl_biast message to beginning of output so that it's clear what is generating further logs when journalled with other output.