### PR TITLE
Install only a statically-linked rtl_biast binary. Do not install librtlsdr or package references.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,16 +154,6 @@ set(exec_prefix \${prefix})
 set(libdir \${exec_prefix}/${LIB_INSTALL_DIR})
 set(includedir \${prefix}/include)
 
-CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/librtlsdr.pc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/librtlsdr.pc
-@ONLY)
-
-INSTALL(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/librtlsdr.pc
-    DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
-)
-
 ########################################################################
 # Print Summary
 ########################################################################

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -16,12 +16,3 @@
 # along with GNU Radio; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-
-########################################################################
-# Install public header files
-########################################################################
-install(FILES
-    rtl-sdr.h
-    rtl-sdr_export.h
-    DESTINATION include
-)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,22 +20,6 @@
 ########################################################################
 # Setup library
 ########################################################################
-add_library(rtlsdr_shared SHARED
-    librtlsdr.c
-    tuner_e4k.c
-    tuner_fc0012.c
-    tuner_fc0013.c
-    tuner_fc2580.c
-    tuner_r82xx.c
-)
-target_link_libraries(rtlsdr_shared
-    ${LIBUSB_LIBRARIES}
-)
-set_target_properties(rtlsdr_shared PROPERTIES DEFINE_SYMBOL "rtlsdr_EXPORTS")
-set_target_properties(rtlsdr_shared PROPERTIES OUTPUT_NAME rtlsdr)
-set_target_properties(rtlsdr_shared PROPERTIES SOVERSION ${MAJOR_VERSION})
-set_target_properties(rtlsdr_shared PROPERTIES VERSION ${LIBVER})
-
 add_library(rtlsdr_static STATIC
     librtlsdr.c
     tuner_e4k.c
@@ -53,7 +37,7 @@ add_library(convenience_static STATIC
     convenience/convenience.c
 )
 target_link_libraries(convenience_static
-    rtlsdr_shared
+    rtlsdr_static
 )
 
 if(NOT WIN32)
@@ -65,9 +49,9 @@ endif()
 # Build utility
 ########################################################################
 add_executable(rtl_biast rtl_biast.c)
-set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_biast)
+set(INSTALL_TARGETS rtl_biast)
 
-target_link_libraries(rtl_biast convenience_static rtlsdr_shared
+target_link_libraries(rtl_biast convenience_static
     ${LIBUSB_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
@@ -88,7 +72,5 @@ endif()
 # Install built library files & utilities
 ########################################################################
 install(TARGETS ${INSTALL_TARGETS}
-    LIBRARY DESTINATION ${LIB_INSTALL_DIR} # .so/.dylib file
-    ARCHIVE DESTINATION ${LIB_INSTALL_DIR} # .lib file
-    RUNTIME DESTINATION bin              # .dll file
+    RUNTIME DESTINATION bin              # binary
 )


### PR DESCRIPTION
Since the included version of `librtlsdr` is now quite old, it's best not to install it and potentially cause version conflicts in certain cases. This version removes the shared build of `librtlsdr` and links `rtl_biast` only to the static version of the library. Also removed are install references to the `librtlsdr` package definition file (`.pc`) and the library's `include` headers. Resolves my issue #11.